### PR TITLE
RFC: A few functions to ease stdmod boilerplate

### DIFF
--- a/lib/puppet/parser/functions/default_content.rb
+++ b/lib/puppet/parser/functions/default_content.rb
@@ -1,0 +1,22 @@
+Puppet::Parser::Functions.newfunction(:default_content,
+                                      :type => :rvalue,
+                                      :doc => <<-'ENDOFDOC'
+Takes an optional content and an optional template name to calculate the actual
+contents of a file.
+
+This small function abbreviates the default initialisation boilerplate of
+stdmod modules.
+ENDOFDOC
+) do |args|
+    content = args[0]
+    template_name = args[1]
+
+    Puppet::Parser::Functions.autoloader.loadall
+
+    return content if content
+    return function_template(template_name) if template_name
+
+    return nil
+  end
+end
+

--- a/lib/puppet/parser/functions/pickx.rb
+++ b/lib/puppet/parser/functions/pickx.rb
@@ -1,0 +1,31 @@
+Puppet::Parser::Functions.newfunction(:pickx,
+                                      :type => :rvalue,
+                                      :doc => <<-EOS
+
+This function is similar to a coalesce function in SQL in that it will return
+the first value in a list of values that is not undefined or an empty string
+(two things in Puppet that will return a boolean false value). Typically,
+this function is used to check for a value in the Puppet Dashboard/Enterprise
+Console, and failover to a default value like the following:
+
+  $real_jenkins_version = pick($::jenkins_version, '1.449')
+
+The value of $real_jenkins_version will first look for a top-scope variable
+called 'jenkins_version' (note that parameters set in the Puppet Dashboard/
+Enterprise Console are brought into Puppet as top-scope variables), and,
+failing that, will use a default value of 1.449.
+
+Contrary to the pick() function from stdlib, this one won't die if all values
+are empty.
+
+EOS
+) do |args|
+   args = args.compact
+   args.delete(:undef)
+   args.delete(:undefined)
+   args.delete("")
+   args << :undefined
+   return args[0]
+ end
+end
+

--- a/manifests/conf.pp.erb
+++ b/manifests/conf.pp.erb
@@ -69,48 +69,14 @@ define <%= metadata.name %>::conf (
 
   include <%= metadata.name %>
 
-  $manage_path = $path ? {
-    undef   => "${<%= metadata.name %>::config_dir_path}/${name}",
-    default => $path,
-  }
-
-  $manage_content = $content ? {
-    undef   => $template ? {
-      undef => undef,
-      default => template($template),
-    },
-    default => $content,
-  }
-
-  $manage_mode = $mode ? {
-    undef   => $<%= metadata.name %>::config_file_mode,
-    default => $mode,
-  }
-
-  $manage_owner = $owner ? {
-    undef   => $<%= metadata.name %>::config_file_owner,
-    default => $owner,
-  }
-
-  $manage_group = $group ? {
-    undef   => $<%= metadata.name %>::config_file_group,
-    default => $group,
-  }
-
-  $manage_require = $require ? {
-    undef   => $<%= metadata.name %>::config_file_require,
-    default => $require,
-  }
-
-  $manage_notify = $notify ? {
-    undef   => $<%= metadata.name %>::manage_config_file_notify,
-    default => $notify,
-  }
-
-  $manage_replace = $replace ? {
-    undef   => $<%= metadata.name %>::config_file_replace,
-    default => $replace,
-  }
+  $manage_path    = pickx($path, "${<%= metadata.name %>::config_dir_path}/${name}")
+  $manage_content = choose_default($content, $template)
+  $manage_mode    = pickx($mode, $<%= metadata.name %>::config_file_mode)
+  $manage_owner   = pickx($owner, $<%= metadata.name %>::config_file_owner)
+  $manage_group   = pickx($group, $<%= metadata.name %>::config_file_group)
+  $manage_require = pickx($require, $<%= metadata.name %>::config_file_require)
+  $manage_notify  = pickx($notify, $<%= metadata.name %>::manage_config_file_notify)
+  $manage_replace = pickx($replace, $<%= metadata.name %>::config_file_replace)
 
   file { "<%= metadata.name %>_conf_${name}":
     ensure  => $ensure,

--- a/manifests/init.pp.erb
+++ b/manifests/init.pp.erb
@@ -68,27 +68,10 @@ class <%= metadata.name %> (
   $config_file_group          = $<%= metadata.name %>::params::config_file_group
   $config_file_mode           = $<%= metadata.name %>::params::config_file_mode
 
-  if $config_file_content {
-    $manage_config_file_content = $config_file_content
-  } else {
-    if $config_file_template {
-      $manage_config_file_content = template($config_file_template)
-    } else {
-      $manage_config_file_content = undef
-    }
-  }
+  $manage_config_file_content = default_content($config_file_content, $config_file_template)
 
-  if $config_file_notify {
-    $manage_config_file_notify = $config_file_notify
-  } else {
-    $manage_config_file_notify = undef
-  }
-
-  if $version {
-    $manage_package_ensure = $version
-  } else {
-    $manage_package_ensure = $ensure
-  }
+  $manage_config_file_notify = pickx($config_file_notify)
+  $manage_package_ensure = pickx($version, $ensure)
 
   if $ensure == 'absent' {
     $manage_service_enable = undef


### PR DESCRIPTION
A common trend in criticizing the stdmod seems to be the amount of
repetitive boilerplate code that goes into init.pp.

This commit has two functions which reduce the boilerplate code in the
standard skeleton significantly. To be fair, the conf.pp could be using
the already existing pick from puppetlabs-stdlib as well.

The two functions should probably go to stdlib, and maybe deserve a better
name.
