### PR TITLE
Delete require and notify from conf.pp.erb , this are metaparameters and...

### DIFF
--- a/manifests/conf.pp.erb
+++ b/manifests/conf.pp.erb
@@ -57,8 +57,6 @@ define <%= metadata.name %>::conf (
   $mode         = undef,
   $owner        = undef,
   $group        = undef,
-  $notify       = 'class_default',
-  $require      = undef,
   $replace      = undef,
 
   $options_hash = undef,


### PR DESCRIPTION
... brakes the syntax check
## 

~ # puppet parser validate manifests/conf.pp
Warning: notify is a metaparam; this value will inherit to all contained resources in the varnish::conf definition
Warning: require is a metaparam; this value will inherit to all contained resources in the varnish::conf definition

~ # rake syntax:manifests --trace
*\* Invoke syntax:manifests (first_time)
*\* Execute syntax:manifests
---> syntax:manifests
rake aborted!
notify is a metaparam; this value will inherit to all contained resources in the varnish::conf definition
require is a metaparam; this value will inherit to all contained resources in the varnish::conf definition
/var/lib/gems/1.9.1/gems/puppet-syntax-1.1.0/lib/puppet-syntax/tasks/puppet-syntax.rb:25:in `block (2 levels) in initialize'
/var/lib/gems/1.9.1/gems/rake-10.1.0/lib/rake/task.rb:234:in`call'
/var/lib/gems/1.9.1/gems/rake-10.1.0/lib/rake/task.rb:234:in `block in execute'
/var/lib/gems/1.9.1/gems/rake-10.1.0/lib/rake/task.rb:231:in`each'
/var/lib/gems/1.9.1/gems/rake-10.1.0/lib/rake/task.rb:231:in `execute'
/var/lib/gems/1.9.1/gems/rake-10.1.0/lib/rake/task.rb:175:in`block in invoke_with_call_chain'
/usr/lib/ruby/1.9.1/monitor.rb:211:in `mon_synchronize'
/var/lib/gems/1.9.1/gems/rake-10.1.0/lib/rake/task.rb:168:in`invoke_with_call_chain'
/var/lib/gems/1.9.1/gems/rake-10.1.0/lib/rake/task.rb:161:in `invoke'
/var/lib/gems/1.9.1/gems/rake-10.1.0/lib/rake/application.rb:149:in`invoke_task'
/var/lib/gems/1.9.1/gems/rake-10.1.0/lib/rake/application.rb:106:in `block (2 levels) in top_level'
/var/lib/gems/1.9.1/gems/rake-10.1.0/lib/rake/application.rb:106:in`each'
/var/lib/gems/1.9.1/gems/rake-10.1.0/lib/rake/application.rb:106:in `block in top_level'
/var/lib/gems/1.9.1/gems/rake-10.1.0/lib/rake/application.rb:115:in`run_with_threads'
/var/lib/gems/1.9.1/gems/rake-10.1.0/lib/rake/application.rb:100:in `top_level'
/var/lib/gems/1.9.1/gems/rake-10.1.0/lib/rake/application.rb:78:in`block in run'
/var/lib/gems/1.9.1/gems/rake-10.1.0/lib/rake/application.rb:165:in `standard_exception_handling'
/var/lib/gems/1.9.1/gems/rake-10.1.0/lib/rake/application.rb:75:in`run'
/var/lib/gems/1.9.1/gems/rake-10.1.0/bin/rake:33:in `<top (required)>'
/usr/local/bin/rake:23:in`load'
/usr/local/bin/rake:23:in `<main>'
Tasks: TOP => syntax:manifests
